### PR TITLE
revised the initial login view

### DIFF
--- a/src/ateamcomp354/projectmanagerapp/ui/LoginPanel.java
+++ b/src/ateamcomp354/projectmanagerapp/ui/LoginPanel.java
@@ -35,6 +35,7 @@ public class LoginPanel {
 	}
 	
 	public void logout() {
+		loggedInUser = null;
 		loginPanelGen.getUsernameField().setText("");
 		loginPanelGen.getPasswordField().setText("");
 		loginPanelGen.getValidityLabel().setText("");
@@ -49,12 +50,12 @@ public class LoginPanel {
 		
 		public void actionPerformed(ActionEvent e){
 			
-			LoginService l = appCtx.getLoginService();
+			LoginService ls = appCtx.getLoginService();
 			try
 			{
 				String username = loginPanelGen.getUsernameField().getText();
 				String password = new String(loginPanelGen.getPasswordField().getPassword());
-				loggedInUser = l.login( username , password );
+				loggedInUser = ls.login( username , password );
 				if (loggedInUser.getManagerRole())
 				{
 					swap.showProjectsView();
@@ -67,7 +68,6 @@ public class LoginPanel {
 			}
 			catch (LoginFailedException lfe)
 			{
-				loginPanelGen.getUsernameField().setText("");
 				loginPanelGen.getPasswordField().setText("");
 				loginPanelGen.getValidityLabel().setText("Invalid username/password combination");
 			}

--- a/src/ateamcomp354/projectmanagerapp/ui/LogoutListener.java
+++ b/src/ateamcomp354/projectmanagerapp/ui/LogoutListener.java
@@ -11,7 +11,7 @@ public class LogoutListener implements ActionListener {
 	}
 	
 	public void actionPerformed(ActionEvent e) {
-		swap.showLoginView("logout");
+		swap.showLoginView();
 	}
 
 }

--- a/src/ateamcomp354/projectmanagerapp/ui/MainFrame.java
+++ b/src/ateamcomp354/projectmanagerapp/ui/MainFrame.java
@@ -73,22 +73,14 @@ public class MainFrame extends JFrame implements SwapInterface{
 		setJMenuBar( menuBar );
 	}
 
-	@Override
 	public void showView( String name ) {
 		cardLayout.show( getContentPane(), name);
 	}
 	
 	@Override
 	public void showLoginView() {
+		loginPanel.logout();
 		cardLayout.show( getContentPane(), LOGIN_PANEL);
-	}
-	
-	public void showLoginView(String logout) {
-		if (logout.equals("logout"))
-		{
-			loginPanel.logout();
-			cardLayout.show( getContentPane(), LOGIN_PANEL);
-		}
 	}
 	
 	@Override

--- a/src/ateamcomp354/projectmanagerapp/ui/SwapInterface.java
+++ b/src/ateamcomp354/projectmanagerapp/ui/SwapInterface.java
@@ -1,12 +1,8 @@
 package ateamcomp354.projectmanagerapp.ui;
 
 public interface SwapInterface {
-	
-	public void showView( String name );
-	
+
 	public void showLoginView();
-	
-	public void showLoginView(String logout);
 	
 	public void showProjectsView();
 	


### PR DESCRIPTION
on logout, null the last logged in user

renamed variable "l" to "ls" just because it could look like a 1 depending on the font
(nit pick thing)

Don't clear the user name field on invalid login, most apps only clear the password but the user name always remains.

Removed the redundant showLoginView(String logout), I think anytime we show the login view
we want the view to reset.